### PR TITLE
Removed a bug.

### DIFF
--- a/matlab_src/Str2mat.m
+++ b/matlab_src/Str2mat.m
@@ -19,7 +19,7 @@ function mat = Str2mat(str)
   % Compute row index for each character.
   x = double(str);   x(:) = 0;
   x(strSep(1:(end-1))+1) = 1;
-  i = cumsum(x) + 1;  i(end) = i(end-1);
+  i = cumsum(x) + 1;  %i(end) = i(end-1);
 
   % Compute col index for each character.
   x(:) = 1;


### PR DESCRIPTION
[The issue is explained here.](https://github.com/Accla/d4m/issues/6)

The bug replaced the first letter of second-last row with the separator if the string ended with two separators. The problematic code portion, which allocated the row value of second-last element to the last element, was commented out. The code is unnecessary in all other cases since the row value of last element will be equal to row value of second-last element in all cases where the string does not end with more than one separators, i.e. the second-last element is not same as last element of the string.